### PR TITLE
#162773919 Integrate github with coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,24 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=
 language: node_js
 node_js:
   - "stable"
+
+after_success: 
+  - "npm test"
+
+before_script:
+  - npm install nyc
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+script:
+  - npm test
+
+after_script:
+  - npm run coverage
+  - npm run cc-coverage
+  - ./cc-test-reporter format-coverage -t lcov .coverage/lcov.info
+  - ./cc-test-reporter upload-coverage $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.com/daniellamarr/merry-sims-test.svg?branch=master)](https://travis-ci.com/daniellamarr/merry-sims-test)
 
+[![Coverage Status](https://coveralls.io/repos/github/daniellamarr/merry-sims-test/badge.svg)](https://coveralls.io/github/daniellamarr/merry-sims-test)
+
 # Todo App
 
 Todo App helps keep track of a user's activities.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint .",
     "lintfix": "./node_modules/.bin/eslint . --fix",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "cc-coverage": "nyc report --reporter=lcov",
+    "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",
@@ -20,8 +22,14 @@
   },
   "homepage": "https://github.com/abejide001/merry-sims-test#readme",
   "devDependencies": {
+    "chai": "^4.2.0",
+    "coveralls": "^3.0.2",
     "eslint": "^5.11.1",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.14.0"
-  }
+    "eslint-plugin-import": "^2.14.0",
+    "mocha": "^5.2.0",
+    "mocha-lcov-reporter": "^1.3.0",
+    "nyc": "^13.1.0"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
### **What does this PR do?**
Integrate github with coveralls

### **Description of task to be completed**
- added coveralls badge to README.MD
- Integrated coveralls with github repository
- added travis build and report script for coveralls to .travis.yml file
- added travis build and report script for code climate to .travis.yml file
- added coveralls and code climate script commands to package.json file (npm run coverage or nom run cc-coverage)

### **How should this be manually tested?**
- clone the repo;
- check out to ch-integrate-github-with-coveralls-and-code-climate-badges-162773919
- navigate to project root folder via command line
- run `npm install` to install all dependencies
- run `npm run coverage` or `npm run cc-coverage` in project root folder to test commands
- To view coverage stats [https://coveralls.io/github/daniellamarr](url)

### **What are the relevant Stories?**
story type: chore
story Id: #162773919
story title: Integrate github with coveralls

### **Screenshots**
N/A

### **Questions:**
N/A